### PR TITLE
chore: add five-language README sync gate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Install harness workspace
         working-directory: harness
         run: pnpm install --frozen-lockfile
+        - name: Readme sync (five languages)
+          run: pnpm run check:readmes
 
       - name: Run skill pack verification
         working-directory: harness

--- a/README.es.md
+++ b/README.es.md
@@ -176,6 +176,8 @@ Todas las opciones son campos Schemastery `Config` (modificables desde cordis.ym
 | `vet.maxExtractBytes` | `67108864` | Tope de bytes de extracción |
 | `vet.maxDepNodes` | `600` | Tope de nodos del árbol de dependencias |
 | `vet.maxFindingsPerCheck` | `12` | Tope de hallazgos por comprobación |
+| `vet.dataResponsibility` | `true` | Ejecuta la revisión de responsabilidad de datos (desactivable por despliegue) |
+| `vet.externalScanners` | `true` | Orquesta `osv-scanner`/`npm audit` cuando sus CLIs están presentes; `false` fuerza el escaneo de dependencias autoconsultado integrado |
 | `vet.userAgent` | `dsh-skill-pack-security/2.2.0 (+https://github.com/PerryLink/dsh-skill-pack-security)` | User-agent de descarga |
 | `vet.gate.policy` | `warn` | Puerta de instalación: `warn` (no bloqueante) o `deny` (bloquea ante FAIL) |
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -177,6 +177,8 @@ bash ./scripts/install.sh --target user-agents --language en
 | `vet.maxExtractBytes` | `67108864` | निष्कर्षण बाइट सीमा |
 | `vet.maxDepNodes` | `600` | डिपेंडेंसी-वृक्ष नोड सीमा |
 | `vet.maxFindingsPerCheck` | `12` | प्रति जाँच निष्कर्ष सीमा |
+| `vet.dataResponsibility` | `true` | डेटा-ज़िम्मेदारी समीक्षा चलाएँ (तैनाती अनुसार अक्षम करने योग्य) |
+| `vet.externalScanners` | `true` | जब उनके CLI मौजूद हों तो `osv-scanner`/`npm audit` का संचालन करें; `false` अंतर्निहित स्व-गणित निर्भरता स्कैन बाध्य करता है |
 | `vet.userAgent` | `dsh-skill-pack-security/2.2.0 (+https://github.com/PerryLink/dsh-skill-pack-security)` | डाउनलोड user-agent |
 | `vet.gate.policy` | `warn` | इंस्टॉल गेट: `warn` (गैर-अवरोधक) या `deny` (FAIL पर रोकें) |
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -176,6 +176,8 @@ Todas as opções são campos Schemastery `Config` (modificáveis a partir do co
 | `vet.maxExtractBytes` | `67108864` | Teto de bytes de extração |
 | `vet.maxDepNodes` | `600` | Teto de nós da árvore de dependências |
 | `vet.maxFindingsPerCheck` | `12` | Teto de achados por verificação |
+| `vet.dataResponsibility` | `true` | Executa a revisão de responsabilidade de dados (desativável por implantação) |
+| `vet.externalScanners` | `true` | Orquestra `osv-scanner`/`npm audit` quando seus CLIs estão presentes; `false` força a verificação de dependências autoconsultada integrada |
 | `vet.userAgent` | `dsh-skill-pack-security/2.2.0 (+https://github.com/PerryLink/dsh-skill-pack-security)` | User-agent de download |
 | `vet.gate.policy` | `warn` | Portão de instalação: `warn` (não bloqueante) ou `deny` (bloqueia ante FAIL) |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -177,6 +177,8 @@ bash ./scripts/install.sh --target user-agents --language en
 | `vet.maxExtractBytes` | `67108864` | 解压字节上限 |
 | `vet.maxDepNodes` | `600` | 依赖树节点上限 |
 | `vet.maxFindingsPerCheck` | `12` | 每项检查的发现数上限 |
+| `vet.dataResponsibility` | `true` | 运行数据责任审查（可按部署禁用） |
+| `vet.externalScanners` | `true` | 当 `osv-scanner`/`npm audit` CLI 存在时编排它们；`false` 强制使用内置自计算依赖扫描 |
 | `vet.userAgent` | `dsh-skill-pack-security/2.2.0 (+https://github.com/PerryLink/dsh-skill-pack-security)` | 下载用的 user-agent |
 | `vet.gate.policy` | `warn` | 安装门禁：`warn`（不阻断）或 `deny`（FAIL 时阻断） |
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Automated plugin supply-chain security gate for DeepSeek Harness (dsh): eight agent skills in Chinese and English editions teach the audit methodology, and the plugin_vet tool executes the pre-install gate (license / SBOM / commit pinning / malicious patterns / five-dimension risk card) with findings that cite the matching skill sections.",
   "license": "Apache-2.0",
   "type": "module",
+  "scripts": {
+    "check:readmes": "node scripts/check-readme-sync.mjs"
+  },
   "engines": {
     "node": "^22.19.0 || >=24.0.0"
   },

--- a/scripts/check-readme-sync.mjs
+++ b/scripts/check-readme-sync.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Five-language README sync gate: the English file is the source of truth.
+// Every translation must carry the same `## ` section headings in the same
+// order and the same configuration-table keys, so a config change cannot
+// ship without its translations.
+import { readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const LANGUAGES = [
+  ['README.md', 'en'],
+  ['README.zh.md', 'zh'],
+  ['README.es.md', 'es'],
+  ['README.pt.md', 'pt'],
+  ['README.hi.md', 'hi'],
+]
+
+const headingsOf = (text) => text.split(/\r?\n/u)
+  .map(line => /^##\s+(.+)$/u.exec(line)?.[1]?.trim())
+  .filter((heading) => heading !== undefined)
+
+// Configuration-table keys: the first cell of every row under the
+// "Configuration" section (until the next `## ` heading).
+const configKeysOf = (text) => {
+  const lines = text.split(/\r?\n/u)
+  const start = lines.findIndex(line => /^##\s+Configuration\s*$/u.test(line))
+  if (start === -1) return []
+  const end = lines.findIndex((line, index) => index > start && line.startsWith('## '))
+  const section = lines.slice(start, end === -1 ? undefined : end)
+  const keys = []
+  let headerSkipped = false
+  for (const line of section) {
+    if (!line.startsWith('|')) continue
+    if (!headerSkipped) { headerSkipped = true; continue }
+    const cells = line.split('|').map(cell => cell.trim())
+    if (cells.length < 2) continue
+    const key = cells[1]
+    if (key === '' || key === 'Key') continue
+    if (/^-+$/u.test(key)) continue
+    keys.push(key)
+  }
+  return keys
+}
+
+const failures = []
+const reference = LANGUAGES[0]
+if (reference === undefined) process.exit(1)
+const refPath = path.join(root, reference[0])
+if (!existsSync(refPath)) {
+  console.error(`${reference[0]} is missing`)
+  process.exit(1)
+}
+const refText = readFileSync(refPath, 'utf8')
+const refHeadings = headingsOf(refText)
+const refKeys = configKeysOf(refText)
+
+for (const [file, label] of LANGUAGES.slice(1)) {
+  const filePath = path.join(root, file)
+  if (!existsSync(filePath)) {
+    failures.push(`${file}: missing (${label})`)
+    continue
+  }
+  const text = readFileSync(filePath, 'utf8')
+  const headings = headingsOf(text)
+  for (let index = 0; index < refHeadings.length; index++) {
+    if (headings[index] !== refHeadings[index]) {
+      failures.push(`${file}: heading ${index + 1} is ${JSON.stringify(headings[index])}, expected ${JSON.stringify(refHeadings[index])}`)
+    }
+  }
+  if (headings.length !== refHeadings.length) {
+    failures.push(`${file}: ${headings.length} headings, expected ${refHeadings.length}`)
+  }
+  const keys = configKeysOf(text)
+  if (keys.length !== refKeys.length) {
+    failures.push(`${file}: ${keys.length} config keys, expected ${refKeys.length}`)
+    continue
+  }
+  for (let index = 0; index < refKeys.length; index++) {
+    if (keys[index] !== refKeys[index]) {
+      failures.push(`${file}: config key ${index + 1} is ${JSON.stringify(keys[index])}, expected ${JSON.stringify(refKeys[index])}`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('readme-sync failed:')
+  for (const failure of failures) console.error(`  - ${failure}`)
+  process.exit(1)
+}
+console.log(`readme-sync: all ${LANGUAGES.length} READMEs share section structure and config keys`)


### PR DESCRIPTION
Adds the check-readme-sync five-language gate (section structure + configuration keys, header-position aware), the `check:readmes` npm script, and a verify-workflow step. Also restores two configuration-key rows missing from the zh/es/pt/hi tables.